### PR TITLE
Support for standard tasks Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,11 +2,13 @@
 module.exports = function (grunt) {
 	grunt.initConfig({
 		xo: {
-			validate: ['test/fixture.js']
+			testTask: {
+				src: ['test/*.js']
+			}
 		},
 		shell: {
 			xo: {
-				command: 'grunt xo',
+				command: 'grunt xo:testTask',
 				options: {
 					callback: function (_, stdout, stderr, cb) {
 						if (/test\/fixture\.js/.test(stdout)) {

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,11 @@ grunt.initConfig({
 			quiet: true
 		},
 		target: ['file.js']
+
+		// or
+		subTask: {
+			src: ['file.js']
+		}
 	}
 });
 
@@ -42,7 +47,7 @@ In the Gruntfile you can specify the following options:
 
 ### outputFile
 
-Type: `string`  
+Type: `string`
 Default: `''`
 
 Output the report to a file.
@@ -50,7 +55,7 @@ Output the report to a file.
 
 ### quiet
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Report errors only.

--- a/tasks/xo.js
+++ b/tasks/xo.js
@@ -9,25 +9,27 @@ module.exports = function (grunt) {
 			quiet: false
 		});
 
-		xo.lintFiles(this.filesSrc).then(function (report) {
-			var results = report.results;
+		this.files.forEach(function (f) {
+			xo.lintFiles(f.orig.src).then(function (report) {
+				var results = report.results;
 
-			if (opts.quiet) {
-				results = xo.getErrorResults(results);
-			}
+				if (opts.quiet) {
+					results = xo.getErrorResults(results);
+				}
 
-			var output = xo.getFormatter()(results);
+				var output = xo.getFormatter()(results);
 
-			if (opts.outputFile) {
-				grunt.file.write(opts.outputFile, output);
-			} else {
-				console.log(output);
-			}
+				if (opts.outputFile) {
+					grunt.file.write(opts.outputFile, output);
+				} else {
+					console.log(output);
+				}
 
-			cb(report.errorCount === 0);
-		}).catch(function (err) {
-			grunt.warn(err);
-			cb();
+				cb(report.errorCount === 0);
+			}).catch(function (err) {
+				grunt.warn(err);
+				cb();
+			});
 		});
 	});
 };


### PR DESCRIPTION
This PR adds the ability to use standard tasks Grunt. This functionality can be useful when checking files in conjunction with `grunt-contrib-watch`.
